### PR TITLE
root jest package with __mocks__ directory - add react-markdown.js fi…

### DIFF
--- a/jest/__mocks__/react-markdown.js
+++ b/jest/__mocks__/react-markdown.js
@@ -1,0 +1,8 @@
+const React = require('react');
+
+// Minimal mock of react-markdown for Jest: just render children
+function ReactMarkdown({ children, className }) {
+  return React.createElement('div', { className }, children);
+}
+
+module.exports = ReactMarkdown;

--- a/jest/__mocks__/react-markdown.js
+++ b/jest/__mocks__/react-markdown.js
@@ -1,5 +1,16 @@
 const React = require('react');
 
+/**
+ * TODO:
+ * Replace ReactMarkdown component.
+ *
+ * ReactMarkdown is ESM only, which is incompatible with jest.
+ * Custom config is required to make it work
+ *
+ * This mock creates a compatible ReactMarkdown for tests globally.
+ * Ideally remove ReactMarkdown and remove this mock, and install a compatible mardown/html renderer
+ */
+
 // Minimal mock of react-markdown for Jest: just render children
 function ReactMarkdown({ children, className }) {
   return React.createElement('div', { className }, children);


### PR DESCRIPTION
…le to handle ESM issue with react-markdown in unit tests - this would mean all unit tests would use the mock

The reason for this is that jest cannot handle ESM imports, and react-markdown is an ESM only package:
https://www.npmjs.com/package/react-markdown

---

The PR offers an alternative approach to the solution setup in this PR:
https://github.com/joepk90/portfolio/pull/40/files

So rather than removing `react-markdown` from the barrel export, we could create a global jest mock?

---


Another solution here is to find a different package to render markdown....